### PR TITLE
ntrip: server: delay starting UART sleep timer until connected to caster

### DIFF
--- a/main/ntrip_server.c
+++ b/main/ntrip_server.c
@@ -113,9 +113,7 @@ static void ntrip_server_task(void *ctx) {
             uart_nmea("$PESP,NTRIP,SRV,WAITING");
             xEventGroupWaitBits(server_event_group, DATA_READY_BIT, true, false, portMAX_DELAY);
         }
-
-        vTaskResume(sleep_task);
-
+        
         wait_for_ip();
 
         char *buffer = NULL;
@@ -161,6 +159,8 @@ static void ntrip_server_task(void *ctx) {
         // Connected
         xEventGroupSetBits(server_event_group, CASTER_READY_BIT);
 
+        vTaskResume(sleep_task);
+        
         // Await disconnect from UART handler
         vTaskSuspend(NULL);
 
@@ -172,9 +172,9 @@ static void ntrip_server_task(void *ctx) {
         ESP_LOGW(TAG, "Disconnected from %s:%d/%s", host, port, mountpoint);
         uart_nmea("$PESP,NTRIP,SRV,DISCONNECTED,%s:%d,%s", host, port, mountpoint);
 
-        _error:
         vTaskSuspend(sleep_task);
-
+        
+        _error:
         destroy_socket(&sock);
 
         free(buffer);


### PR DESCRIPTION
In pull request #14 you said "you'd want to  … a check for CASTER_READY_BIT before writing".

I confess that I had assumed that was implicit, but having checked I do see that the timer is resumed before the connection to caster process (which can take >10 seconds to complete) starts which got me wondering whether that is what we want - or whether the 10s clock should only start ticking once the connection is made as it was in the original code.

What do you think? This way seems more logical to be, but please reject if there are good reasons for doing it the other way.



